### PR TITLE
correct the compilation on 64bit machines

### DIFF
--- a/nudefs.h
+++ b/nudefs.h
@@ -10,9 +10,16 @@
  */
 
 /* SYSTEM DEPENDENCIES */
+#include <bits/types.h>
+#if __WORDSIZE == 64
+typedef unsigned char onebyt;
+typedef unsigned short int twobyt;
+typedef unsigned int fourbyt;
+#else
 typedef unsigned char onebyt;
 typedef unsigned short twobyt;
 typedef unsigned long fourbyt;
+#endif
 
 /* byte ordering; TRUE if high byte is first (68xxx), else FALSE (65xxx) */
 extern int HiLo;  /* actually part of numain.c */


### PR DESCRIPTION
64 bit machines define  unsigned long integers as 64-bit wide.

This adds a check (possibly non-portable) for wordsize of 64-bit  and typedef's  "fourbyt" correctly for 64-bit systems.